### PR TITLE
Replaced all conditions to a short syntax

### DIFF
--- a/src/SeoUtf8Slugger.php
+++ b/src/SeoUtf8Slugger.php
@@ -32,7 +32,7 @@ class SeoUtf8Slugger extends SeoSlugger implements SluggerInterface
      */
     public static function slugify($string, $separator = null)
     {
-        $separator = (null !== $separator) ? $separator : ((null !== self::$separator) ? self::$separator : '-');
+        $separator = $separator ?: (self::$separator ?: '-');
         $string = self::expandString($string);
 
         $slug = trim(strip_tags($string));
@@ -52,7 +52,7 @@ class SeoUtf8Slugger extends SeoSlugger implements SluggerInterface
      */
     public static function uniqueSlugify($string, $separator = null)
     {
-        $separator = (null !== $separator) ? $separator : ((null !== self::$separator) ? self::$separator : '-');
+        $separator = $separator ?: (self::$separator ?: '-');
         $string = self::expandString($string);
 
         $slug = self::slugify($string, $separator);

--- a/src/Slugger.php
+++ b/src/Slugger.php
@@ -20,7 +20,7 @@ class Slugger implements SluggerInterface
 
     public function __construct($separator = null)
     {
-        self::$separator = (null !== $separator) ? $separator : '-';
+        self::$separator = $separator ?: '-';
     }
 
     /**
@@ -28,7 +28,7 @@ class Slugger implements SluggerInterface
      */
     public static function slugify($string, $separator = null)
     {
-        $separator = (null !== $separator) ? $separator : ((null !== self::$separator) ? self::$separator : '-');
+        $separator = $separator ?: (self::$separator ?: '-');
 
         $slug = trim(strip_tags($string));
         $slug = self::transliterate($slug);
@@ -44,7 +44,7 @@ class Slugger implements SluggerInterface
      */
     public static function uniqueSlugify($string, $separator = null)
     {
-        $separator = (null !== $separator) ? $separator : ((null !== self::$separator) ? self::$separator : '-');
+        $separator = $separator ?: (self::$separator ?: '-');
 
         $slug = self::slugify($string, $separator);
         $slug .= $separator.substr(md5(mt_rand()), 0, 7);

--- a/src/Utf8Slugger.php
+++ b/src/Utf8Slugger.php
@@ -27,7 +27,7 @@ class Utf8Slugger implements SluggerInterface
             throw new \RuntimeException('Unable to use Utf8Slugger (it requires PHP >= 5.4.0 and intl >= 2.0 extension).');
         }
 
-        self::$separator = (null !== $separator) ? $separator : '-';
+        self::$separator = $separator ?: '-';
     }
 
     /**
@@ -35,7 +35,7 @@ class Utf8Slugger implements SluggerInterface
      */
     public static function slugify($string, $separator = null)
     {
-        $separator = (null !== $separator) ? $separator : ((null !== self::$separator) ? self::$separator : '-');
+        $separator = $separator ?: (self::$separator ?: '-');
 
         $slug = trim(strip_tags($string));
         $slug = transliterator_transliterate(
@@ -54,7 +54,7 @@ class Utf8Slugger implements SluggerInterface
      */
     public static function uniqueSlugify($string, $separator = null)
     {
-        $separator = (null !== $separator) ? $separator : ((null !== self::$separator) ? self::$separator : '-');
+        $separator = $separator ?: (self::$separator ?: '-');
 
         $slug = self::slugify($string, $separator);
         $slug .= $separator.substr(md5(mt_rand()), 0, 7);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |

From PHP.net

> Since PHP 5.3, it is possible to leave out the middle part of the ternary operator. Expression expr1 ?: expr3 returns expr1 if expr1 evaluates to TRUE, and expr3 otherwise.
